### PR TITLE
Update README to reflect new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bugless
+# Bug Buster
 
 <img align="right" height="400" src="logo.png">
 
@@ -6,15 +6,15 @@ Bug bounty programs allow developers to discover vulnerabilities in their applic
 They are mostly held in the Web2 space, and, thus, rarely provide any form of payment guarantee to whitehats.
 As a result, developers are able to unfairly underpay whitehats, or even refuse to pay them.
 
-To solve this issue, we have developed Bugless—a trustless bug bounty platform powered by [Cartesi Rollups](https://www.cartesi.io/).
-Running inside a deterministic RISC-V machine that boots Linux, Bugless accepts applications written in any major programming language[^1].
+To solve this issue, we have developed Bug Buster—a trustless bug bounty platform powered by [Cartesi Rollups](https://www.cartesi.io/).
+Running inside a deterministic RISC-V machine that boots Linux, Bug Buster accepts applications written in any major programming language[^1].
 Through a friendly web interface, anyone can submit applications, and sponsor them with Ether to incentivize hackers! All major wallets are supported[^2].
 Meanwhile, hackers can test their exploits right on the browser, without even having to sign Web3 transactions!
 Once the hacker finds a valid exploit, they can finally send a transaction requesting the reward to be transferred to their account.
 If, however, no one is able to submit a valid exploit until a certain deadline, the sponsors may request a refund.
 
-[^1]: Some notable examples of programming languages that can run inside Bugless are C, C++, Python, Lua, JavaScript, and Rust.
-[^2]: Bugless supports +300 wallets, such as WalletConnect, MetaMask, Trust Wallet, and Coinbase.
+[^1]: Some notable examples of programming languages that can run inside Bug Buster are C, C++, Python, Lua, JavaScript, and Rust.
+[^2]: Bug Buster supports +300 wallets, such as WalletConnect, MetaMask, Trust Wallet, and Coinbase.
 
 ## Dependencies
 
@@ -88,7 +88,7 @@ make test
 
 ## CLI
 
-To interact with the contract, you may use the Bugless CLI.
+To interact with the contract, you may use the Bug Buster CLI.
 For all the options, run the command below.
 
 ```sh
@@ -181,7 +181,7 @@ Below are some of those features.
 
 ## Debugging
 
-When running Bugless locally, you might want to perform some operations that would otherwise be impossible in a production environment.
+When running Bug Buster locally, you might want to perform some operations that would otherwise be impossible in a production environment.
 To this end, we advise you to install the [Foundry](https://book.getfoundry.sh/getting-started/installation) toolkit.
 
 ### Time travel


### PR DESCRIPTION
The README is still featuring the old name (Bugless).
This PR changes it to reflect the new one (Bugbuster)