### PR TITLE
fix: check preconditions before running exploit code for the solidity bounty

### DIFF
--- a/tests/bounties/solidity-bounty/start.sh
+++ b/tests/bounties/solidity-bounty/start.sh
@@ -1,4 +1,44 @@
 #!/bin/sh
+
+#
+# Validate exploit code - Exploit code file must contain only ascii characters
+#
+grep -q "[^[:print:]]" $1 
+status=$?
+if [ $status -eq 0 ]; then
+    >&2 echo "Invalid exploit code: File contains non-ascii characters"
+    exit 1
+fi
+if [ $status -eq 2 ]; then
+    >&2 echo "Invalid exploit code: Error reading the file"
+    exit 1
+fi
+
+
+#
+# Validate exploit code - No experimental directives are allowed
+#
+grep -q "experimental" $1
+status=$?
+if [ $status -eq 0 ]; then
+    >&2 echo "Invalid exploit code: contains 'experimental' keyword"
+    exit 1
+fi
+
+
+#
+# Validate exploit code - Requires specific version of Solidity
+#
+grep -q "pragma solidity 0.8.26" $1
+status=$?
+if [ $status -eq 1 ]; then
+    >&2 echo "Invalid exploit code: pragma solidity 0.8.26 not found"
+    exit 1
+fi
+
+#
+# Run the exploit code
+#
 ./solc $1
 status=$?
 # Status is always 139 when program crashes with "Segmentation fault" (SIGSEGV)

--- a/tests/bounties/solidity-bounty/start.sh
+++ b/tests/bounties/solidity-bounty/start.sh
@@ -5,36 +5,23 @@
 #
 grep -q "[^[:print:]]" $1 
 status=$?
-if [ $status -eq 0 ]; then
-    >&2 echo "Invalid exploit code: File contains non-ascii characters"
-    exit 1
-fi
-if [ $status -eq 2 ]; then
-    >&2 echo "Invalid exploit code: Error reading the file"
+if [ $status -ne 1 ]; then
+    >&2 echo "Invalid exploit code: Error searching for non-ascii characters"
     exit 1
 fi
 
 
 #
 # Validate exploit code - No experimental directives are allowed
+# See: https://github.com/ethereum/solidity/issues/15223
 #
 grep -q "experimental" $1
 status=$?
-if [ $status -eq 0 ]; then
-    >&2 echo "Invalid exploit code: contains 'experimental' keyword"
+if [ $status -ne 1 ]; then
+    >&2 echo "Invalid exploit code: Error searching for 'experimental' keyword"
     exit 1
 fi
 
-
-#
-# Validate exploit code - Requires specific version of Solidity
-#
-grep -q "pragma solidity 0.8.26" $1
-status=$?
-if [ $status -eq 1 ]; then
-    >&2 echo "Invalid exploit code: pragma solidity 0.8.26 not found"
-    exit 1
-fi
 
 #
 # Run the exploit code


### PR DESCRIPTION
From the github repo @edubart discovered some known issues that could break the bounty. The following preconditions were added to the assertion script:
- Require the 0.8.26 solidity version
- Reject exploit code containing the experimental directive
- Reject exploit code if it contain non-ascii character

The result of the new assertion script when we submit the code that allowed Eduardo to break the bounty is presented below.

The goal is to deploy it asap while so people can continue playing with it on testnet and meanwhile redo the analysis of the solidity compiler github repo to check if there are other known issues to be added as preconditions.

![image](https://github.com/user-attachments/assets/e8519945-00e3-416d-9e14-308ce41b8dcd)