### PR TITLE
fix: Landing page responsive

### DIFF
--- a/frontend/src/app/header.tsx
+++ b/frontend/src/app/header.tsx
@@ -7,6 +7,7 @@ import {
     Divider,
     Tooltip,
     Stack,
+    Flex,
 } from "@mantine/core";
 import { FC } from "react";
 import { RiMoneyDollarCircleLine } from "react-icons/ri";
@@ -41,20 +42,23 @@ export const Header: FC = () => {
                     </Anchor>
                 </Center>
             </Group>
-            <Group h="100%" px={20}>
-                <Group justify="flex-end">
-                    <Anchor href="/" underline="never">
-                        <Title>🪲 Bug Buster</Title>
-                    </Anchor>
-                </Group>
-                <Group justify="flex-end" style={{ flex: 1 }}>
+            <Flex px={20}>
+                <Anchor href="/" underline="never">
+                    <Title>🪲 Bug Buster</Title>
+                </Anchor>
+
+                <Group
+                    justify="flex-end"
+                    style={{ flex: 1 }}
+                    visibleFrom={"sm"}
+                >
                     <HasConnectedAccount>
                         <VoucherNotification />
                     </HasConnectedAccount>
                     <Divider orientation="vertical" />
                     <ConnectButton />
                 </Group>
-            </Group>
+            </Flex>
         </Stack>
     );
 };

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,40 +1,54 @@
 "use client";
 import { FC } from "react";
-import { Button, Stack, Card, Text, Group } from "@mantine/core";
+import { Button, Card, Text, Flex, Title } from "@mantine/core";
 import Link from "next/link";
 import { GH_README_URL } from "../utils/links";
 
 const Home: FC = () => {
     return (
-        <Stack align="center">
-            <Card mt={20} ml={20} mr={20} withBorder>
-                <Stack mt="md" mb="md" align="center">
-                    <Text size="40px">A Trustless</Text>
-                    <Text size="40px">Bug Bounty Platform</Text>
-                </Stack>
+        <Flex direction={"row"} justify={"center"}>
+            <Card
+                mt={20}
+                ml={20}
+                mr={20}
+                withBorder
+                w={{ base: "300px", sm: "720px" }}
+            >
+                <Flex mt="md" mb="md" direction={"column"} align={"center"}>
+                    <Title>A Trustless Bug Bounty Platform</Title>
 
-                <Text c="dimmed" w={720} mb="md">
-                    Bug Buster accepts software written in any major programming
-                    language. Through a friendly web interface, hackers can test
-                    their exploits right on the browser, without even having to
-                    sign Web3 transactions! Once the hacker finds a valid
-                    exploit, they can finally send a transaction requesting the
-                    reward to be transferred to their account. All major wallets
-                    are supported!
-                </Text>
+                    <Text c="dimmed" mb="md">
+                        Bug Buster accepts software written in any major
+                        programming language. Through a friendly web interface,
+                        hackers can test their exploits right on the browser,
+                        without even having to sign Web3 transactions! Once the
+                        hacker finds a valid exploit, they can finally send a
+                        transaction requesting the reward to be transferred to
+                        their account. All major wallets are supported!
+                    </Text>
+                </Flex>
 
-                <Group justify="space-between">
-                    <Link href={"/explore"}>
-                        <Button size="lg">Explore Bounties</Button>
-                    </Link>
-                    <Link href={GH_README_URL}>
-                        <Button variant="outline" size="lg">
+                <Flex
+                    direction={{ base: "column", sm: "row" }}
+                    gap="md"
+                    justify={"space-between"}
+                >
+                    <Link
+                        href={GH_README_URL}
+                        style={{ textDecoration: "none" }}
+                    >
+                        <Button fullWidth variant="outline" size="lg">
                             Learn more
                         </Button>
                     </Link>
-                </Group>
+                    <Link href={"/explore"} style={{ textDecoration: "none" }}>
+                        <Button fullWidth size="lg">
+                            Explore Bounties
+                        </Button>
+                    </Link>
+                </Flex>
             </Card>
-        </Stack>
+        </Flex>
     );
 };
 


### PR DESCRIPTION
This PR makes the landing page responsive. As analytics showed most visitors are coming from mobile. This is part of epic #21 .

Before the PR:
![image](https://github.com/user-attachments/assets/bef0141e-d122-4a9b-965b-104ca0673294)

After the PR:
![image](https://github.com/user-attachments/assets/7286fde5-9580-4da3-9926-053439f3dc57)
