### PR TITLE
Bump `cartesi` to 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To help you figure out which dependencies you actually need, here is a table of 
 | `go` | 1.21.1 | | | | | ☑️ | ☑️ | |
 | `jq` | 1.6 | | | | | ☑️ | | |
 | `pnpm` | 8.15.6 | | | | | | | ☑️ |
-| `cartesi` | 0.14.0 | | ☑️ | | ☑️ | | | |
+| `cartesi` | 0.16.0 | | ☑️ | | ☑️ | | | |
 
 ## Presentation
 


### PR DESCRIPTION
Maybe the most important upgrade is to 0.15.0, which comes with the new node 1.5.0.
But let's bump it to the latest version, which allows a `--json` option to be passed to the `cartesi deploy build` command, which might be useful to automate the build of the Cartesi Node image in the CI.