### PR TITLE
Add `paths-ignore` filter to `push` events on `main` for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - 'cli'
+      - 'cloud'
+      - 'frontend'
     tags:
       - 'v*'
 


### PR DESCRIPTION
Reference: [`paths-ignore` on GitHub Docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)