### PR TITLE
Bump versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,17 @@
 
 ################################################################################
 # cross build stage
-FROM ubuntu:24.04 as build-stage
+FROM ubuntu:noble-20240801 as build-stage
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt update
-apt upgrade -y
 apt install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    g++-riscv64-linux-gnu \
-    wget
+    build-essential=12.10ubuntu1 \
+    ca-certificates=20240203 \
+    g++-riscv64-linux-gnu=4:13.2.0-7ubuntu1 \
+    wget=1.21.4-1ubuntu4.1
 EOF
 
 ARG GOVERSION=1.23.0
@@ -39,18 +38,17 @@ RUN go build -o ./dapp ./contract
 
 ################################################################################
 # riscv64 build stage
-FROM --platform=linux/riscv64 ubuntu:24.04 as riscv64-build-stage
+FROM --platform=linux/riscv64 ubuntu:noble-20240801 as riscv64-build-stage
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt update
-apt upgrade -y
 apt install -y --no-install-recommends \
-    lua5.4 \
-    build-essential \
-    ca-certificates \
-    wget
+    lua5.4=5.4.6-3build2 \
+    build-essential=12.10ubuntu1 \
+    ca-certificates=20240203 \
+    wget=1.21.4-1ubuntu4.1
 EOF
 
 WORKDIR /opt/build
@@ -84,7 +82,7 @@ EOF
 
 ################################################################################
 # runtime stage: produces final image that will be executed
-FROM --platform=linux/riscv64 ubuntu:24.04
+FROM --platform=linux/riscv64 ubuntu:noble-20240801
 
 LABEL io.cartesi.sdk_version=0.9.0
 LABEL io.cartesi.rollups.ram_size=128Mi
@@ -96,14 +94,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get update
-apt-get upgrade -y
 apt-get install -y --no-install-recommends \
-    busybox-static \
-    ca-certificates \
-    curl \
-    libasan6 \
-    libasan8 \
-    xz-utils
+    busybox-static=1:1.36.1-6ubuntu3.1 \
+    ca-certificates=20240203 \
+    curl=8.5.0-2ubuntu10.3 \
+    libasan6=11.4.0-9ubuntu1 \
+    libasan8=14-20240412-0ubuntu1 \
+    xz-utils=5.6.1+really5.4.5-1build0.1
 curl -o ${MACHINE_EMULATOR_TOOLS_DEB} -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/${MACHINE_EMULATOR_TOOLS_DEB}
 dpkg -i ${MACHINE_EMULATOR_TOOLS_DEB}
 rm ${MACHINE_EMULATOR_TOOLS_DEB}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 ################################################################################
 # cross build stage
-FROM ubuntu:22.04 as build-stage
+FROM ubuntu:24.04 as build-stage
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -39,7 +39,7 @@ RUN go build -o ./dapp ./contract
 
 ################################################################################
 # riscv64 build stage
-FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as riscv64-build-stage
+FROM --platform=linux/riscv64 ubuntu:24.04 as riscv64-build-stage
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
@@ -84,9 +84,8 @@ EOF
 
 ################################################################################
 # runtime stage: produces final image that will be executed
-FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
+FROM --platform=linux/riscv64 ubuntu:24.04
 
-LABEL io.cartesi.sdk_version=0.6.0
 LABEL io.cartesi.sdk_version=0.9.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 LABEL io.cartesi.rollups.data_size=128Mb

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ apt install -y --no-install-recommends \
     wget
 EOF
 
-ARG GOVERSION=1.21.1
+ARG GOVERSION=1.23.0
 
 WORKDIR /opt/build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ EOF
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
 LABEL io.cartesi.sdk_version=0.6.0
+LABEL io.cartesi.sdk_version=0.9.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 LABEL io.cartesi.rollups.data_size=128Mb
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,10 +2,10 @@ FROM cartesi/sdk:0.9.0
 
 RUN apt-get update
 RUN apt-get install -y \
-  build-essential \
-  git \
-  lua5.4-dev \
-  luarocks
+  build-essential=12.9 \
+  git=1:2.39.2-1.1 \
+  liblua5.4-dev=5.4.4-3+deb12u1 \
+  luarocks=3.8.0+dfsg1-1
 RUN <<EOF
 luarocks install --lua-version=5.4 cartesix
 luarocks install --lua-version=5.4 lester

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM cartesi/sdk:0.6.0
+FROM cartesi/sdk:0.9.0
 
 RUN apt-get update
 RUN apt-get install -y build-essential luarocks lua5.4-dev git

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,7 +1,11 @@
 FROM cartesi/sdk:0.9.0
 
 RUN apt-get update
-RUN apt-get install -y build-essential luarocks lua5.4-dev git
+RUN apt-get install -y \
+  build-essential \
+  git \
+  lua5.4-dev \
+  luarocks
 RUN <<EOF
 luarocks install --lua-version=5.4 cartesix
 luarocks install --lua-version=5.4 lester

--- a/tests/bounties/busybox-bounty/Dockerfile
+++ b/tests/bounties/busybox-bounty/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
+FROM --platform=linux/riscv64 ubuntu:24.04
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y --no-install-recommends ca-certificates build-essential wget xz-utils
 WORKDIR /root

--- a/tests/bounties/busybox-bounty/Dockerfile
+++ b/tests/bounties/busybox-bounty/Dockerfile
@@ -1,6 +1,9 @@
-FROM --platform=linux/riscv64 ubuntu:24.04
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y --no-install-recommends ca-certificates build-essential wget xz-utils
+FROM --platform=linux/riscv64 ubuntu:noble-20240801
+RUN apt-get install -y --update --no-install-recommends \
+  build-essential=12.10ubuntu1 \
+  ca-certificates=20240203 \
+  wget=1.21.4-1ubuntu4.1 \
+  xz-utils=5.6.1+really5.4.5-1build0.1
 WORKDIR /root
 COPY Makefile .
 COPY filter_exit.patch .

--- a/tests/bounties/busybox-bounty/Makefile
+++ b/tests/bounties/busybox-bounty/Makefile
@@ -5,7 +5,7 @@ SOURCE_DIR=busybox-$(VERSION)
 BOUNTY_TAR=busybox-$(VERSION)-bounty_$(ARCH).tar.xz
 BOUNTY_RISCV64_TAR=busybox-$(VERSION)-bounty_riscv64.tar.xz
 
-HARDEN_CFLAGS=-Os -D_FORTIFY_SOURCE=2 -fPIE -fstack-clash-protection -fstack-protector-strong -ffunction-sections -fdata-sections -Wno-unused-result
+HARDEN_CFLAGS=-O1 -ftrivial-auto-var-init=pattern -D_FORTIFY_SOURCE=2 -fPIE -fstack-clash-protection -fstack-protector-strong -ffunction-sections -fdata-sections -Wno-unused-result
 HARDEN_LDFLAGS=-pie -Wl,-z,now,-z,relro,--gc-sections -s
 
 # Use GitHub Actions cache when available

--- a/tests/bounties/lua-bounty/Dockerfile
+++ b/tests/bounties/lua-bounty/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
+FROM --platform=linux/riscv64 ubuntu:24.04
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y --no-install-recommends ca-certificates build-essential wget xz-utils
 WORKDIR /root

--- a/tests/bounties/lua-bounty/Dockerfile
+++ b/tests/bounties/lua-bounty/Dockerfile
@@ -1,6 +1,9 @@
-FROM --platform=linux/riscv64 ubuntu:24.04
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y --no-install-recommends ca-certificates build-essential wget xz-utils
+FROM --platform=linux/riscv64 ubuntu:noble-20240801
+RUN apt-get install -y --update --no-install-recommends \
+  build-essential=12.10ubuntu1 \
+  ca-certificates=20240203 \
+  wget=1.21.4-1ubuntu4.1 \
+  xz-utils=5.6.1+really5.4.5-1build0.1
 WORKDIR /root
 COPY Makefile .
 COPY bounty.lua .

--- a/tests/bounties/lua-bounty/Makefile
+++ b/tests/bounties/lua-bounty/Makefile
@@ -5,7 +5,7 @@ SOURCE_DIR=lua-$(VERSION)
 BOUNTY_TAR=lua-$(VERSION)-bounty_$(ARCH).tar.xz
 BOUNTY_RISCV64_TAR=lua-$(VERSION)-bounty_riscv64.tar.xz
 
-HARDEN_CFLAGS=-Os -D_FORTIFY_SOURCE=2 -fexceptions -fPIE -fstack-clash-protection -fstack-protector-strong -ffunction-sections -fdata-sections
+HARDEN_CFLAGS=-O1 -ftrivial-auto-var-init=pattern -D_FORTIFY_SOURCE=2 -fexceptions -fPIE -fstack-clash-protection -fstack-protector-strong -ffunction-sections -fdata-sections
 HARDEN_LDFLAGS=-pie -Wl,-z,now,-z,relro,--gc-sections -s
 
 # Use GitHub Actions cache when available

--- a/tests/bounties/solidity-bounty/Dockerfile
+++ b/tests/bounties/solidity-bounty/Dockerfile
@@ -1,13 +1,12 @@
-FROM ubuntu:24.04 as base-builder
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y --no-install-recommends \
-    build-essential \
-    ca-certificates \
-    crossbuild-essential-riscv64 \
-    git \
-    make \
-    wget \
-    xz-utils
+FROM ubuntu:noble-20240801 as base-builder
+RUN apt-get install -y --update --no-install-recommends \
+    build-essential=12.10ubuntu1 \
+    ca-certificates=20240203 \
+    crossbuild-essential-riscv64=12.10ubuntu1 \
+    git=1:2.43.0-1ubuntu7.1 \
+    make=4.3-4.1build2 \
+    wget=1.21.4-1ubuntu4.1 \
+    xz-utils=5.6.1+really5.4.5-1build0.1
 
 #
 # Build Boost
@@ -32,7 +31,7 @@ RUN ./b2 toolset=gcc-riscv64 link=static variant=release runtime-link=static \
 
 FROM base-builder as solidity-builder
 WORKDIR /opt/build
-RUN apt-get install -y --no-install-recommends cmake
+RUN apt-get install -y --no-install-recommends cmake=3.28.3-1build7
 ARG VERSION
 RUN wget -O solidity-${VERSION}.tar.gz https://github.com/ethereum/solidity/releases/download/v${VERSION}/solidity_${VERSION}.tar.gz
 RUN tar xzf solidity-${VERSION}.tar.gz

--- a/tests/bounties/solidity-bounty/Dockerfile
+++ b/tests/bounties/solidity-bounty/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as base-builder
+FROM ubuntu:24.04 as base-builder
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y --no-install-recommends \
     build-essential \

--- a/tests/bounties/solidity-bounty/Dockerfile
+++ b/tests/bounties/solidity-bounty/Dockerfile
@@ -36,6 +36,8 @@ ARG VERSION
 RUN wget -O solidity-${VERSION}.tar.gz https://github.com/ethereum/solidity/releases/download/v${VERSION}/solidity_${VERSION}.tar.gz
 RUN tar xzf solidity-${VERSION}.tar.gz
 COPY --from=boost-builder /opt/boost /opt/boost
+ENV CFLAGS="-O1 -ftrivial-auto-var-init=pattern -D_FORTIFY_SOURCE=2 -fPIE -fstack-clash-protection -fstack-protector-strong -ffunction-sections -fdata-sections -Wno-unused-result"
+ENV CXXFLAGS=$CFLAGS
 RUN cmake \
     -S solidity_${VERSION} \
     -B solidity_${VERSION}/build \

--- a/tests/bounties/sqlite-bounty/Dockerfile
+++ b/tests/bounties/sqlite-bounty/Dockerfile
@@ -1,7 +1,11 @@
-FROM --platform=linux/riscv64 ubuntu:24.04
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y --no-install-recommends ca-certificates build-essential wget xz-utils
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tclsh
+FROM --platform=linux/riscv64 ubuntu:noble-20240801
+RUN apt-get install -y --update --no-install-recommends \
+  build-essential=12.10ubuntu1 \
+  ca-certificates=20240203 \
+  wget=1.21.4-1ubuntu4.1 \
+  xz-utils=5.6.1+really5.4.5-1build0.1
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  tcl8.6=8.6.14+dfsg-1build1
 WORKDIR /root
 COPY Makefile .
 COPY --chmod=755 start.sh .

--- a/tests/bounties/sqlite-bounty/Dockerfile
+++ b/tests/bounties/sqlite-bounty/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
+FROM --platform=linux/riscv64 ubuntu:24.04
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y --no-install-recommends ca-certificates build-essential wget xz-utils
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tclsh

--- a/tests/bounties/sqlite-bounty/Makefile
+++ b/tests/bounties/sqlite-bounty/Makefile
@@ -6,7 +6,7 @@ BOUNTY_TAR=sqlite-$(VERSION)-bounty_$(ARCH).tar.xz
 BOUNTY_RISCV64_TAR=sqlite-$(VERSION)-bounty_riscv64.tar.xz
 
 CC=gcc
-HARDEN_CFLAGS=-Os -D_FORTIFY_SOURCE=2 -fPIE -fstack-clash-protection -fstack-protector-strong -ffunction-sections -fdata-sections
+HARDEN_CFLAGS=-O1 -ftrivial-auto-var-init=pattern -D_FORTIFY_SOURCE=2 -fPIE -fstack-clash-protection -fstack-protector-strong -ffunction-sections -fdata-sections
 HARDEN_LDFLAGS=-pie -Wl,-z,now,-z,relro,--gc-sections
 SQLITE_CFLAGS=-DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_LOAD_EXTENSION
 SQLITE_LDFLAGS=-lm -s


### PR DESCRIPTION
Since Ubuntu released oficial ricvs64 container images for 24.04, I suggest bumping its versions.

Also bumped cartesi/sdk and golang.

I just built but didn't test if everything worked.