### PR TITLE
Create bounty for solidity 0.8.27

### DIFF
--- a/populate.sh
+++ b/populate.sh
@@ -182,17 +182,17 @@ SOLIDITY_DESCRIPTION=$(jq -r '.description' "$SOLIDITY_INFO_FILE")
 SOLIDITY_IMG_LINK=$(jq -r '.imgLink' "$SOLIDITY_INFO_FILE")
 SOLIDITY_SPONSOR_NAME="Spencer Smart"
 
-# 0.8.26
+# 0.8.27
 
 bounty_index=$(go run ./cli state | jq '.bounties | length')
 
 go run ./cli send bounty \
     -f "$DEV_ACCOUNT" \
-    -n "Solidity 0.8.26" \
+    -n "Solidity 0.8.27" \
     -i "$SOLIDITY_IMG_LINK" \
     -d "$SOLIDITY_DESCRIPTION" \
     --duration "$ONE_DAY" \
-    -p '/bounties/examples/solidity-0.8.26-bounty_riscv64.tar.xz' \
+    -p '/bounties/examples/solidity-0.8.27-bounty_riscv64.tar.xz' \
     -t "$TOKEN_ADDRESS"
 
 go run ./cli send sponsor \

--- a/tests/bounties/Makefile
+++ b/tests/bounties/Makefile
@@ -7,7 +7,7 @@ all:
 
 	$(MAKE) -C busybox-bounty riscv64 VERSION=1.36.1
 
-	$(MAKE) -C solidity-bounty riscv64 VERSION=0.8.26
+	$(MAKE) -C solidity-bounty riscv64 VERSION=0.8.27
 
 clean:
 	$(MAKE) -C lua-bounty clean

--- a/tests/bounties/solidity-bounty/Makefile
+++ b/tests/bounties/solidity-bounty/Makefile
@@ -1,5 +1,6 @@
-ARCH=$(shell uname -m)
-VERSION=0.8.27
+ifndef VERSION
+    $(error VERSION is not set for Solidity.)
+endif
 BOUNTY_RISCV64_TAR=solidity-$(VERSION)-bounty_riscv64.tar.xz
 
 # Use GitHub Actions cache when available

--- a/tests/bounties/solidity-bounty/Makefile
+++ b/tests/bounties/solidity-bounty/Makefile
@@ -1,5 +1,5 @@
 ARCH=$(shell uname -m)
-VERSION=0.8.26
+VERSION=0.8.27
 BOUNTY_RISCV64_TAR=solidity-$(VERSION)-bounty_riscv64.tar.xz
 
 # Use GitHub Actions cache when available

--- a/tests/bounties/solidity-bounty/info.json
+++ b/tests/bounties/solidity-bounty/info.json
@@ -1,4 +1,4 @@
 {
-    "description": "Find bugs in Solidity, the most popular programming language for smart contracts!\n\nSubmit Solidity code and try to crash the compiler exit with a segmentation fault status (code 139).\n\nThe source code of the bounty can be inspected at:\nhttps://github.com/crypto-bug-hunters/bug-buster/tree/main/tests/bounties/solidity-bounty",
-    "imgLink": "https://docs.soliditylang.org/en/v0.8.26/_static/img/logo-dark.svg"
+  "description": "Find bugs in Solidity, the most popular programming language for smart contracts!\n\nSubmit Solidity code and try to crash the compiler exit with a segmentation fault status (code 139).\n\nThe source code of the bounty can be inspected at:\nhttps://github.com/crypto-bug-hunters/bug-buster/tree/main/tests/bounties/solidity-bounty",
+  "imgLink": "https://docs.soliditylang.org/en/v0.8.27/_static/img/logo-dark.svg"
 }


### PR DESCRIPTION
Solidity 0.8.27 was officially launched then we will close the current bounty for 0.8.26 and open a new one for the new release.