### PR TITLE
Specify package manager for root package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,6 @@
     },
     "devDependencies": {
         "@cartesi/cli": "0.16.0"
-    }
+    },
+    "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
 }


### PR DESCRIPTION
When [`corepack`](https://nodejs.org/api/corepack.html) is enabled, it looks for this field when `pnpm` is executed.

Source: https://nodejs.org/api/packages.html#packagemanager