### PR TITLE
feat: use `apt update --snapshot` for reproducibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ ARG APT_UPDATE_SNAPSHOT=${NOBLE_DATE}T030400Z
 # cross base stage
 FROM ubuntu:noble-${NOBLE_DATE} AS base-build-stage
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
 apt update
 apt install -y --no-install-recommends ca-certificates
 apt update --snapshot=${APT_UPDATE_SNAPSHOT}
@@ -19,11 +20,12 @@ EOF
 
 ################################################################################
 # riscv64 base stage
-FROM --platform=linux/riscv64 ubuntu:noble-${NOBLE_DATE} as base-target-stage
+FROM --platform=linux/riscv64 ubuntu:noble-${NOBLE_DATE} AS base-target-stage
 
+ARG APT_UPDATE_SNAPSHOT
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
-set -e
+set -eu
 apt update
 apt install -y --no-install-recommends ca-certificates
 apt update --snapshot=${APT_UPDATE_SNAPSHOT}


### PR DESCRIPTION
This PR will change the main Dockerfile to use the `apt update --snapshot` option to lock the Ubuntu repository into a specific point in time.

See: https://snapshot.ubuntu.com

So, we don't need to pin package versions anymore and get the guarantee that the package versions used and their dependencies will always be the same.

When we want to change the date, we just need to change the `ARG NOBLE_DATE` to a desired values.

I'm reusing this same `ARG` to the `apt update --snapshot=` and for the Oficial Ubuntu Docker Image tag that has a date, like `ubuntu:noble-20240801`.

If we desire to change this date in the future, we can look what's the latest dated version available at https://hub.docker.com/_/ubuntu

> Noble Numbat is the codename for the latest Ubuntu LTS version, which is 24.04.