### PR TITLE
Add grype vulnerability scanner to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,12 @@ jobs:
       - name: Install Node.js dependencies
         run: pnpm i
 
+      - name: Scan image
+        uses: anchore/scan-action@v3
+        with:
+          image: ${{ steps.build_machine.outputs.imageid }}
+          fail-build: false
+
       - name: Build Cartesi Machine image
         env:
           IMAGE_ID: ${{ steps.build_machine.outputs.imageid }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Scan image
         id: scan
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v4
         with:
           image: ${{ steps.build_machine.outputs.imageid }}
           fail-build: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,10 +92,19 @@ jobs:
         run: pnpm i
 
       - name: Scan image
+        id: scan
         uses: anchore/scan-action@v3
         with:
           image: ${{ steps.build_machine.outputs.imageid }}
           fail-build: false
+
+      - name: Inspect action SARIF report
+        run: cat ${{ steps.scan.outputs.sarif }}
+
+      - name: Upload vulnerability report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
 
       - name: Build Cartesi Machine image
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ apt install -y --no-install-recommends \
     wget
 EOF
 
-ARG GOVERSION=1.23.0
+ARG GOVERSION=1.23.1
 
 WORKDIR /opt/build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module bug-buster
 
-go 1.22.0
+go 1.23.1
 
 require (
 	github.com/Khan/genqlient v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.1
 require (
 	github.com/Khan/genqlient v0.6.0
 	github.com/cartesi/rollups-node v1.3.0
-	github.com/ethereum/go-ethereum v1.13.12
+	github.com/ethereum/go-ethereum v1.13.15
 	github.com/holiman/uint256 v1.2.4
 	github.com/rollmelette/rollmelette v0.1.1
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/ethereum/c-kzg-4844 v0.4.1 h1:ftiEBwhGX3Q08lJiMEfoSmqiUZPyad0exVSmGLjyPuc=
 github.com/ethereum/c-kzg-4844 v0.4.1/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
-github.com/ethereum/go-ethereum v1.13.12 h1:iDr9UM2JWkngBHGovRJEQn4Kor7mT4gt9rUZqB5M29Y=
-github.com/ethereum/go-ethereum v1.13.12/go.mod h1:hKL2Qcj1OvStXNSEDbucexqnEt1Wh4Cz329XsjAalZY=
+github.com/ethereum/go-ethereum v1.13.15 h1:U7sSGYGo4SPjP6iNIifNoyIAiNjrmQkz6EwQG+/EZWo=
+github.com/ethereum/go-ethereum v1.13.15/go.mod h1:TN8ZiHrdJwSe8Cb6x+p0hs5CxhJZPbqB7hHkaUXcmIU=
 github.com/fjl/memsize v0.0.2 h1:27txuSD9or+NZlnOWdKUxeBzTAUkWCVh+4Gf2dWFOzA=
 github.com/fjl/memsize v0.0.2/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
@@ -100,8 +100,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
-github.com/holiman/billy v0.0.0-20230718173358-1c7e68d277a7 h1:3JQNjnMRil1yD0IfZKHF9GxxWKDJGj8I0IqOUol//sw=
-github.com/holiman/billy v0.0.0-20230718173358-1c7e68d277a7/go.mod h1:5GuXa7vkL8u9FkFuWdVvfR5ix8hRB7DbOAaYULamFpc=
+github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4 h1:X4egAf/gcS1zATw6wn4Ej8vjuVGxeHdan+bRb2ebyv4=
+github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4/go.mod h1:5GuXa7vkL8u9FkFuWdVvfR5ix8hRB7DbOAaYULamFpc=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.2.4 h1:jUc4Nk8fm9jZabQuqr2JzednajVmBpC+oiTiXZJEApU=


### PR DESCRIPTION
This PR will add a scan step into the CI that will upload the SARIF output to GitHub, and it will show security alerts like the ones in this link https://github.com/crypto-bug-hunters/bug-buster/security/code-scanning?query=pr%3A155+is%3Aopen

We should define some policy on where to enforce CI to fail at a certain level of vulnerability or not.

Currently, it's configured not to fail.