### PR TITLE
Remove curl dependency from final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,23 +117,22 @@ LABEL io.cartesi.sdk_version=0.9.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 LABEL io.cartesi.rollups.data_size=128Mb
 
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.14.1
-ARG MACHINE_EMULATOR_TOOLS_DEB=machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -eu
 apt-get install -y --no-install-recommends \
     busybox-static \
-    ca-certificates \
-    curl \
     libasan6 \
     libasan8 \
     xz-utils
-curl -o ${MACHINE_EMULATOR_TOOLS_DEB} -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/${MACHINE_EMULATOR_TOOLS_DEB}
-dpkg -i ${MACHINE_EMULATOR_TOOLS_DEB}
-rm ${MACHINE_EMULATOR_TOOLS_DEB}
 rm -rf /var/lib/apt/lists/*
 EOF
+
+# install machine-emulator-tools
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.14.1
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /tmp
+RUN dpkg -i /tmp/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+  && rm /tmp/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
 COPY --from=riscv64-build-stage /opt/build/bubblewrap/bwrap /usr/bin/bwrap
 COPY --from=riscv64-build-stage /opt/build/bwrapbox/bwrapbox /usr/bin/bwrapbox


### PR DESCRIPTION
This PR will use `Dockerfile`'s ADD instead of `curl` and not having to install `curl` in the final image.

With that, we go from [11 CVEs](https://github.com/crypto-bug-hunters/bug-buster/issues/159) to only 5 according to `grype`´s output.

```
NAME            INSTALLED            FIXED-IN  TYPE  VULNERABILITY   SEVERITY   
busybox-static  1:1.36.1-6ubuntu3.1            deb   CVE-2023-42366  Medium      
busybox-static  1:1.36.1-6ubuntu3.1            deb   CVE-2023-39810  Medium      
libgcrypt20     1.10.3-2build1                 deb   CVE-2024-2236   Medium      
libssl3t64      3.0.13-0ubuntu3.4              deb   CVE-2024-41996  Medium      
openssl         3.0.13-0ubuntu3.4              deb   CVE-2024-41996  Medium
```