### PR TITLE
Give `security-events: write` permission to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      security-events: write
       packages: write
       contents: read
     env:


### PR DESCRIPTION
Source: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github